### PR TITLE
Refactor TutorialManager out of player (precursor to tutorial scene)

### DIFF
--- a/project/PlayerCharacter.gd
+++ b/project/PlayerCharacter.gd
@@ -14,41 +14,22 @@ extends CharacterBody2D
 @export var game_manager: GameManager
 @export var sfx_manager: SfxManager
 
-@export var tutorial_manager: TutorialManager
 @export var g_p_messages_cont: VBoxContainer
 @export var throw_component: Node
-var is_tutorial_section_active: bool = false
-var tut_conn: TutorialManager.TutorialConnector
 
 var base_placer = BasePlacer.new(1)
 var selected: Node2D
 
 signal called_goblins()
 signal died
+signal built_base
+signal lead_goblin
+signal threw_goblin
 
 func _ready():
     base_placer.game_manager = game_manager
     died.connect(_on_died)
     
-    # tutorial: play tutorial when player loads
-    tut_conn = TutorialManager.TutorialConnector.new(tutorial_manager, self, g_p_messages_cont)
-    if tut_conn.connected():
-        await get_tree().create_timer(2).timeout
-        tut_conn.manager.prompter_ready.emit(
-            tut_conn.manager.Section.INSPIRE_PROMPT, 
-            tut_conn,
-            "call"
-        )
-        tut_conn.manager.prompter_ready.emit(
-            tut_conn.manager.Section.THROW_PROMPT,
-            tut_conn,
-            "throw"
-        )
-        tut_conn.manager.prompter_ready.emit(
-            tut_conn.manager.Section.BUILD_PROMPT,
-            tut_conn,
-            "place"
-        )
 
 func _on_died():
     game_manager.game_over.emit(GameManager.GameResult.LOSE)
@@ -93,14 +74,7 @@ func _input(event):
     if event.is_action_pressed("place"):
         if base_placer.is_previewing() and base_placer.can_be_placed:
             base_placer.place(get_parent(), throw_target.global_transform.origin)
-                    # tutorial
-            if tut_conn.connected():
-                if tut_conn.manager.is_tutorial_active():
-                    tut_conn.manager.section_success.emit(
-                        tut_conn.manager.Section.BUILD_PROMPT,
-                        tut_conn.manager.Section.BUILD_RESPONSE, 
-                        tut_conn
-                    )
+            built_base.emit()
         else:
             base_placer.preview(throw_target)
 

--- a/project/goblin_call_area.gd
+++ b/project/goblin_call_area.gd
@@ -50,15 +50,9 @@ func call_goblins():
     var allied_goblins = goblins.filter(func(node: Actor): return node.team == leader.team) as Array[Actor]
     if len(allied_goblins) > 0:
         lead(allied_goblins)
+        leader.lead_goblin.emit()
 
-    # tutorial
-    if leader.tut_conn.connected():   
-        if leader.tut_conn.manager.is_tutorial_active():
-            leader.tut_conn.manager.section_success.emit(
-                leader.tut_conn.manager.Section.INSPIRE_PROMPT, 
-                leader.tut_conn.manager.Section.INSPIRE_RESPONSE, 
-                leader.tut_conn
-            )
+
 
 func show_call_indicator():
     call_range_indicator_timer.start()

--- a/project/main.tscn
+++ b/project/main.tscn
@@ -657,8 +657,10 @@ lead_layer = ExtResource("5_x38i0")
 max_vol = -18
 min_vol = -60
 
-[node name="TutorialManager" type="CanvasLayer" parent="."]
+[node name="TutorialManager" type="CanvasLayer" parent="." node_paths=PackedStringArray("player", "g_p_messages_cont")]
 script = ExtResource("7_fp0kt")
+player = NodePath("../PlayerCharacter")
+g_p_messages_cont = NodePath("../LevelUI/GamePlayMessages")
 prompt_time = 3.0
 response_time = 2.0
 inspire_prompt = "You can inspire goblins follow you. "
@@ -743,10 +745,9 @@ position = Vector2(-3.33333, 0)
 scale = Vector2(1, 0.3)
 texture = ExtResource("3_olnyg")
 
-[node name="PlayerCharacter" parent="." node_paths=PackedStringArray("game_manager", "tutorial_manager", "g_p_messages_cont") instance=ExtResource("1_rjx7k")]
+[node name="PlayerCharacter" parent="." node_paths=PackedStringArray("game_manager", "g_p_messages_cont") instance=ExtResource("1_rjx7k")]
 position = Vector2(449, 533)
 game_manager = NodePath("../GameManager")
-tutorial_manager = NodePath("../TutorialManager")
 g_p_messages_cont = NodePath("../LevelUI/GamePlayMessages")
 
 [node name="Camera2D" type="Camera2D" parent="PlayerCharacter"]

--- a/project/src/character/components/throw_goblin_component.gd
+++ b/project/src/character/components/throw_goblin_component.gd
@@ -20,17 +20,7 @@ func throw_a_goblin():
         return
     var goblin = select_goblin()
     throw_goblin(goblin)
-
-    # tutorial
-    if player.tut_conn.connected():
-        if player.tut_conn.manager.is_tutorial_active():
-            player.tut_conn.manager.section_success.emit(
-                player.tut_conn.manager.Section.THROW_PROMPT,
-                player.tut_conn.manager.Section.THROW_RESPONSE, 
-                player.tut_conn
-            )        
-
-
+    player.threw_goblin.emit()
 
 func _process(_delta):
     if Input.is_action_just_pressed("throw"):


### PR DESCRIPTION
This allows a tutorial to be added to a scene and not require the player to know about or reference the tutorial. Instead, the player emits game events and the tutorial listens for them. This can be extended to include other behaviors like mining and combat if desired.

## Gameplay Demo
https://github.com/loteque/GoblinGame/assets/23508546/c91571b1-ca7b-491d-9858-e132012548af




